### PR TITLE
Use last version of `vinyl-fs` (~0.1.2) to avoid node-gyp/gaze issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "yuidocjs": "~0.3.47",
     "chalk": "~0.4.0",
     "text-table": "~0.2.0",
-    "vinyl-fs": "0.0.2"
+    "vinyl-fs": "~0.1.2"
   },
   "devDependencies": {
     "mocha": "1.17.1",


### PR DESCRIPTION
Currently configured `vinyl-fs` (**0.0.2**) needs native compilation using `node-gyp` for `gaze` dependency crashing on non-developer/compiler configured machines.

**NOTE:** Same issue as jsBoot/gulp-jsdoc#9 and jsBoot/gulp-docco#4
