### PR TITLE
Added an option to 'pretty print' the json output

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,8 @@
 
     var firstFile = null;
 
+    var spaces = options && options.spaces ? options.spaces : 0;
+
     var wp = new Parser(options);
 
     var bufferFiles = function(file, enc, next){
@@ -45,7 +47,7 @@
 
       var data;
       try{
-        data = JSON.stringify(wp.complete());
+        data = JSON.stringify(wp.complete(), null, spaces);
         // data = parser(options, filemap));
       }catch(e){
         return this.emit('error', new PluginError('gulp-jsdoc',


### PR DESCRIPTION
Calling `JSON.stringify(wp.complete());` limits the output options & this PR would allow the user to specify a number to force 'pretty printing' of JSON.

Although the `options` param is directly passed to the YUI lib, they don't use the `spaces` property so I chose to use that, instead of attempting to add a third argument the `parser` method
